### PR TITLE
Ignore stderr from grep

### DIFF
--- a/autoload/hsimport.vim
+++ b/autoload/hsimport.vim
@@ -124,7 +124,7 @@ function! s:source_files_containing(symbol)
   let l:topLevelOpRegex   = '^\(' . a:symbol . '\)\s*::.*$'
   let l:grepRegex         = shellescape(l:dataRegex . "|" . l:typeRegex . "|" . l:topLevelFuncRegex . "|" . l:topLevelOpRegex)
   let l:grepExclude       = '--exclude=.hdevtools.sock --exclude-dir=dist --exclude-dir=.cabal-sandbox'
-  let l:grpCmd            = 'grep -Rl -E ' . l:grepExclude . ' ' . l:grepRegex . ' ' . l:src_dir
+  let l:grpCmd            = 'grep -Rl -E ' . l:grepExclude . ' ' . l:grepRegex . ' ' . l:src_dir . ' 2>/dev/null'
   call s:debug('grpCmd: ' . l:grpCmd)
 
   let l:grepOutput = system(l:grpCmd)


### PR DESCRIPTION
I had an invalid symlink in a subdirectory and the error printed by grep was being treated as a filename which was passed to ghc (via hdevtools?).

I guess the vim `system` function captures both `stdout` and `stderr`.