### PR TITLE
shellescape the "--include=*.hs" (to support zsh with "nomatch" set)

### DIFF
--- a/autoload/hsimport.vim
+++ b/autoload/hsimport.vim
@@ -122,7 +122,7 @@ function! s:source_files_containing(symbol)
   let l:topLevelFuncRegex = '^' . a:symbol . '\s*::.*$'
   let l:topLevelOpRegex = '^\(' . a:symbol . '\)\s*::.*$'
   let l:grepRegex = shellescape(l:dataRegex . "|" . l:typeRegex . "|" . l:topLevelFuncRegex . "|" . l:topLevelOpRegex)
-  let l:grepIncludeExclude = '--include=*.hs --exclude-dir=dist --exclude-dir=.cabal-sandbox'
+  let l:grepIncludeExclude = shellescape('--include=*.hs') . ' --exclude-dir=dist --exclude-dir=.cabal-sandbox'
   let l:grpCmd = 'grep -Rl -E ' . l:grepIncludeExclude . ' ' . l:grepRegex . ' ' . l:srcDir
   call s:debug('grpCmd: ' . l:grpCmd)
 


### PR DESCRIPTION
Hello,

thanks for this very convenient plugin!

`vim-hsimport` passes `--include=*.hs` to `grep`. When using `zsh` as the default shell with the `nomatch` option set (I think it's the default), this produces the error `zsh:1: no matches found: --include=*.hs`.

(Actually, in my case the error was harder to find because I stupidly had something redirecting stderr to stdout in my `shellredir` vim setting. This led to this curious chain of events:

```sh
Calling shell to execute:
(grep -Rl -E --include=*.hs --exclude-dir=dist --exclude-dir=.cabal-sandbox '^data\s*ReaderT.*$|^type\s*ReaderT.*$|^ReaderT\s*::.*$|^\(ReaderT\)\s*::.*$' /some/path) |& unansi >/tmp/v6eqp3y/4 2>&1

Calling shell to execute: 
(hdevtools findsymbol 'ReaderT'  '/some/path/zsh:1: no matches found: --include=*.hs') |& unansi >/tmp/v6eqp3y/5 2>&1

Calling shell to execute: 
(hsimport -m 'hdevtools: <socket: 3>: hGetLine: end of file' -s 'ReaderT'   'src/ArbitraryInstance/Internal/LogicUtil.hs') |& unansi >/tmp/v6eqp3y/6 2>&1
```
)